### PR TITLE
Change mmdet EvalHook to mmcv EvalHook

### DIFF
--- a/mpa/modules/hooks/adaptive_training_hooks.py
+++ b/mpa/modules/hooks/adaptive_training_hooks.py
@@ -5,7 +5,7 @@
 import math
 from mmcv.runner import HOOKS, Hook, LrUpdaterHook
 from mmcv.runner.hooks.checkpoint import CheckpointHook
-from mmcv.runner.evaluation import EvalHook
+from mmcv.runner.hooks.evaluation import EvalHook
 from mpa.utils.logger import get_logger
 from mpa.modules.hooks.early_stopping_hook import EarlyStoppingHook
 

--- a/mpa/modules/hooks/adaptive_training_hooks.py
+++ b/mpa/modules/hooks/adaptive_training_hooks.py
@@ -5,7 +5,7 @@
 import math
 from mmcv.runner import HOOKS, Hook, LrUpdaterHook
 from mmcv.runner.hooks.checkpoint import CheckpointHook
-from mmdet.core.evaluation.eval_hooks import EvalHook
+from mmcv.runner.evaluation import EvalHook
 from mpa.utils.logger import get_logger
 from mpa.modules.hooks.early_stopping_hook import EarlyStoppingHook
 


### PR DESCRIPTION
## Summary
### This PR includes :
- Change mmdet.EvalHook to mmcv.EvalHook for Classification Environment of SC