### PR TITLE
Add ignore_last flag on semgnetation text logger

### DIFF
--- a/recipes/stages/segmentation/class_incr.py
+++ b/recipes/stages/segmentation/class_incr.py
@@ -26,7 +26,7 @@ optimizer_config = dict(
 log_config = dict(
     interval=10,
     hooks=[
-        dict(type='TextLoggerHook', by_epoch=True),
+        dict(type='TextLoggerHook', by_epoch=True, ignore_last=False),
         # dict(type='TensorboardLoggerHook')
     ]
 )


### PR DESCRIPTION
Prevent possible bug : Training graph will not be visualized when number of training sample is smaller than batch size.