### PR TITLE
Add workaround fix when batch size > 1 for MaskRCNN

### DIFF
--- a/mpa/det/trainer.py
+++ b/mpa/det/trainer.py
@@ -71,6 +71,12 @@ class DetectionTrainer(DetectionStage):
         datasets = [build_dataset(cfg.data.train)]
         cfg.data.val.samples_per_gpu = cfg.data.get('samples_per_gpu', 1)
 
+        # FIXME: scale_factors is fixed at 1 even batch_size > 1 in simple_test_mask
+        # Need to investigate, possibly due to OpenVINO
+        if 'roi_head' in model_cfg.model:
+            if 'mask_head' in model_cfg.model.roi_head:
+                cfg.data.val.samples_per_gpu = 1
+
         if hasattr(cfg, 'hparams'):
             if cfg.hparams.get('adaptive_anchor', False):
                 num_ratios = cfg.hparams.get('num_anchor_ratios', 5)


### PR DESCRIPTION
index out of range bug in instance seg after introducing batch size > 1 in this [PR](https://github.com/openvinotoolkit/model_preparation_algorithm/pull/69). For some reason, `scale_factors` in `simple_test_mask` is hardcoded and strictly has only one item in the list  , I'm guessing it's related to OpenVINO export and need some time to investigate