### PR TITLE
Don't apply activations on export in classification

### DIFF
--- a/mpa/modules/models/heads/custom_cls_head.py
+++ b/mpa/modules/models/heads/custom_cls_head.py
@@ -2,6 +2,9 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
+import torch
+import torch.nn.functional as F
+
 from mmcls.models.builder import HEADS
 from mmcls.models.heads import LinearClsHead
 from .non_linear_cls_head import NonLinearClsHead
@@ -82,6 +85,17 @@ class CustomLinearClsHead(LinearClsHead):
             }
         losses['loss'] = loss
         return losses
+
+    def simple_test(self, img):
+        """Test without augmentation."""
+        cls_score = self.fc(img)
+        if isinstance(cls_score, list):
+            cls_score = sum(cls_score) / float(len(cls_score))
+        if torch.onnx.is_in_onnx_export():
+            return cls_score
+        pred = F.softmax(cls_score, dim=1) if cls_score is not None else None
+
+        return self.post_process(pred)
 
     def forward_train(self, x, gt_label):
         cls_score = self.fc(x)

--- a/mpa/modules/models/heads/custom_multi_label_linear_cls_head.py
+++ b/mpa/modules/models/heads/custom_multi_label_linear_cls_head.py
@@ -81,9 +81,9 @@ class CustomMultiLabelLinearClsHead(MultiLabelClsHead):
         cls_score = self.fc(img) * self.scale
         if isinstance(cls_score, list):
             cls_score = sum(cls_score) / float(len(cls_score))
-        pred = torch.sigmoid(cls_score) if cls_score is not None else None
         if torch.onnx.is_in_onnx_export():
-            return pred
+            return cls_score
+        pred = torch.sigmoid(cls_score) if cls_score is not None else None
         pred = list(pred.detach().cpu().numpy())
         return pred
 

--- a/mpa/modules/models/heads/custom_multi_label_non_linear_cls_head.py
+++ b/mpa/modules/models/heads/custom_multi_label_non_linear_cls_head.py
@@ -105,9 +105,9 @@ class CustomMultiLabelNonLinearClsHead(MultiLabelClsHead):
         cls_score = self.classifier(img) * self.scale
         if isinstance(cls_score, list):
             cls_score = sum(cls_score) / float(len(cls_score))
-        pred = torch.sigmoid(cls_score) if cls_score is not None else None
         if torch.onnx.is_in_onnx_export():
-            return pred
+            return cls_score
+        pred = torch.sigmoid(cls_score) if cls_score is not None else None
         pred = list(pred.detach().cpu().numpy())
         return pred
 

--- a/mpa/modules/models/heads/non_linear_cls_head.py
+++ b/mpa/modules/models/heads/non_linear_cls_head.py
@@ -76,9 +76,9 @@ class NonLinearClsHead(ClsHead):
         cls_score = self.classifier(img)
         if isinstance(cls_score, list):
             cls_score = sum(cls_score) / float(len(cls_score))
-        pred = F.softmax(cls_score, dim=1) if cls_score is not None else None
         if torch.onnx.is_in_onnx_export():
-            return pred
+            return cls_score
+        pred = F.softmax(cls_score, dim=1) if cls_score is not None else None
         pred = list(pred.detach().cpu().numpy())
         return pred
 


### PR DESCRIPTION
The motivation is that d-o-r, POT, OpenVINO task and Model API classification components don't expect activated output from IR, so we had wrong confidence results of classification and simply wrong results of multilabel classification in OV tasks / POT. As soon as we remove d-o-r and related code, we can use activated output on the export sage again. 