### PR TITLE
Class-wise saliency map generation for the detection task

### DIFF
--- a/mpa/det/inferrer.py
+++ b/mpa/det/inferrer.py
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 from contextlib import nullcontext
-from typing import List, Tuple
 
 import torch
 from mmcv.parallel import MMDataParallel, is_module_wrapper
@@ -11,7 +10,7 @@ from mmcv.runner import load_checkpoint
 from mmdet.datasets import build_dataloader, build_dataset, replace_ImageToTensor, ImageTilingDataset
 from mmdet.models import build_detector
 from mmdet.parallel import MMDataCPU
-from mmdet.utils.deployment import get_saliency_map, get_feature_vector
+from mmdet.utils.deployment import get_feature_vector
 from mmdet.apis import single_gpu_test
 
 from mpa.registry import STAGES

--- a/mpa/det/inferrer.py
+++ b/mpa/det/inferrer.py
@@ -16,7 +16,7 @@ from mmdet.apis import single_gpu_test
 from mpa.registry import STAGES
 from .stage import DetectionStage
 from mpa.utils.logger import get_logger
-from mpa.modules.hooks.auxiliary_hooks import SaliencyMapHookDet
+from mpa.modules.hooks.auxiliary_hooks import DetSaliencyMapHook
 
 
 logger = get_logger()
@@ -165,9 +165,9 @@ class DetectionInferrer(DetectionStage):
         if is_module_wrapper(model):
             model = model.module
         with eval_model.module.backbone.register_forward_hook(feature_vector_hook):
-            with SaliencyMapHookDet(eval_model.module) if dump_saliency_map else nullcontext() as shook:
+            with DetSaliencyMapHook(eval_model.module) if dump_saliency_map else nullcontext() as saliency_hook:
                 eval_predictions = single_gpu_test(eval_model, data_loader)
-                saliency_maps = shook.records if dump_saliency_map else [None] * len(self.dataset)
+                saliency_maps = saliency_hook.records if dump_saliency_map else [None] * len(self.dataset)
 
         for key in [
                 'interval', 'tmpdir', 'start', 'gpu_collect', 'save_best',

--- a/mpa/modules/hooks/auxiliary_hooks.py
+++ b/mpa/modules/hooks/auxiliary_hooks.py
@@ -134,12 +134,12 @@ class SaliencyMapHook:
         self._handle.remove()
 
 
-class SaliencyMapHookDet(SaliencyMapHook):
+class DetSaliencyMapHook(SaliencyMapHook):
     """While registered with the designated PyTorch module, this class caches the saliency maps during forward pass.
         Saliency maps are generated using classification head outputs
 
     Example:
-        with SaliencyMapHookDet(model.module) as hook:
+        with DetSaliencyMapHook(model.module) as hook:
             with torch.no_grad():
                 result = model(return_loss=False, rescale=True, **data)
             print(hook.records)
@@ -234,7 +234,7 @@ class SaliencyMapHookDet(SaliencyMapHook):
                 cls_scores = list(map_results)
             else:
                 raise NotImplemented("Not supported detection head provided. "
-                                     "SaliencyMapHookDet supports only the following single stage detectors: "
+                                     "DetSaliencyMapHook supports only the following single stage detectors: "
                                      "YOLOXHead, ATSSHead, SSDHead, VFNetHead.")
         return cls_scores
 

--- a/mpa/modules/hooks/auxiliary_hooks.py
+++ b/mpa/modules/hooks/auxiliary_hooks.py
@@ -14,10 +14,12 @@
 
 from __future__ import annotations
 
-from typing import List, Union
+from typing import List, Tuple, Union
 
 import torch
 import mmcls
+
+import mpa
 
 
 class EigenCamHook:
@@ -89,7 +91,7 @@ class SaliencyMapHook:
         return self._records
 
     @staticmethod
-    def func(feature_map: Union[torch.Tensor, list[torch.Tensor]], fpn_idx: int = 0) -> torch.Tensor:
+    def func(feature_map: Union[torch.Tensor, List[torch.Tensor]], fpn_idx: int = 0) -> torch.Tensor:
         """Generate the saliency map by average feature maps then normalizing to (0, 255).
 
         Args:
@@ -130,6 +132,100 @@ class SaliencyMapHook:
 
     def __exit__(self, exc_type, exc_value, traceback):
         self._handle.remove()
+
+
+class SaliencyMapHookDet(SaliencyMapHook):
+    def __init__(self, module: torch.nn.Module) -> None:
+        super().__init__(module.backbone)
+        self._neck = module.neck if module.with_neck else None
+        self._bbox_head = module.bbox_head
+        self._num_cls_out_channels = module.bbox_head.cls_out_channels  # SSD-like heads also have background class
+        if hasattr(module.bbox_head, 'anchor_generator'):
+            self._num_anchors = module.bbox_head.anchor_generator.num_base_anchors
+        else:
+            self._num_anchors = [1] * 10
+
+    def func(self, x: Union[torch.Tensor, List[torch.Tensor], Tuple[torch.Tensor]], _: int = 0, cls_scores_provided: bool = False) -> torch.Tensor:
+        """
+        Generate the saliency map from raw classification head output, then normalizing to (0, 255).
+        :param x:
+        :param cls_scores_provided:
+        :return:
+        """
+        if cls_scores_provided:
+            cls_scores = x
+        else:
+            cls_scores = self._get_cls_scores_from_feature_map(x)
+
+        bs, _, h, w = cls_scores[-1].size()
+        saliency_maps = torch.empty(bs, self._num_cls_out_channels, h, w)
+        for batch_idx in range(bs):
+            cls_scores_anchorless = []
+            for scale_idx, cls_scores_per_scale in enumerate(cls_scores):
+                cls_scores_anchor_grouped = cls_scores_per_scale[batch_idx].reshape(
+                    self._num_anchors[scale_idx],
+                    (self._num_cls_out_channels),
+                    *cls_scores_per_scale.shape[-2:]
+                )
+                cls_scores_out, _ = cls_scores_anchor_grouped.max(dim=0)
+                cls_scores_anchorless.append(cls_scores_out.unsqueeze(0))
+            cls_scores_anchorless_resized = []
+            for cls_scores_anchorless_per_level in cls_scores_anchorless:
+                cls_scores_anchorless_resized.append(
+                    torch.nn.functional.interpolate(
+                        cls_scores_anchorless_per_level,
+                        (h, w),
+                        mode='bilinear'))
+            saliency_maps[batch_idx] = torch.cat(cls_scores_anchorless_resized, dim=0).mean(dim=0)
+
+        saliency_maps = saliency_maps.reshape((bs, self._num_cls_out_channels, -1))
+        max_values, _ = torch.max(saliency_maps, -1)
+        min_values, _ = torch.min(saliency_maps, -1)
+        saliency_maps = (
+                255
+                * (saliency_maps - min_values[:, :, None])
+                / (max_values - min_values + 1e-12)[:, :, None]
+        )
+        saliency_maps = saliency_maps.reshape((bs, self._num_cls_out_channels, h, w))
+        saliency_maps = saliency_maps.to(torch.uint8)
+        return saliency_maps
+
+    def _get_cls_scores_from_feature_map(self, x: torch.Tensor) -> List:
+        """Forward features through the classification head of the detector"""
+        with torch.no_grad():
+            if self._neck is not None:
+                x = self._neck(x)
+
+            if isinstance(self._bbox_head, mpa.modules.models.heads.custom_ssd_head.CustomSSDHead):
+                cls_scores = []
+                for feat, cls_conv in zip(x, self._bbox_head.cls_convs):
+                    cls_scores.append(cls_conv(feat))
+            elif isinstance(self._bbox_head, mpa.modules.models.heads.custom_atss_head.CustomATSSHead):
+                cls_scores = []
+                for cls_feat in x:
+                    for cls_conv in self._bbox_head.cls_convs:
+                        cls_feat = cls_conv(cls_feat)
+                    cls_score = self._bbox_head.atss_cls(cls_feat)
+                    cls_scores.append(cls_score)
+            elif isinstance(self._bbox_head, mpa.modules.models.heads.custom_vfnet_head.CustomVFNetHead):
+                # Not clear how to separate cls_scores from bbox_preds
+                cls_scores, _, _ = self._bbox_head(x)
+            elif isinstance(self._bbox_head, mpa.modules.models.heads.custom_yolox_head.CustomYOLOXHead):
+                def forward_single(x, cls_convs, conv_cls):
+                    """Forward feature of a single scale level."""
+                    cls_feat = cls_convs(x)
+                    cls_score = conv_cls(cls_feat)
+                    return cls_score
+
+                map_results = map(forward_single, x,
+                                  self._bbox_head.multi_level_cls_convs,
+                                  self._bbox_head.multi_level_conv_cls)
+                cls_scores = list(map_results)
+            else:
+                raise NotImplemented("Not supported detection head provided. "
+                                     "SaliencyMapHookDet supports only the following single stage detectors: "
+                                     "YOLOXHead, ATSSHead, SSDHead, VFNetHead.")
+        return cls_scores
 
 
 class ReciproCAMHook(SaliencyMapHook):

--- a/mpa/modules/models/detectors/sam_detector_mixin.py
+++ b/mpa/modules/models/detectors/sam_detector_mixin.py
@@ -2,7 +2,12 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
+import torch
+
 from mmdet.models.detectors import BaseDetector
+from mmdet.utils.deployment.export_helpers import get_feature_vector
+from mmdet.integration.nncf.utils import no_nncf_trace
+from mpa.modules.hooks.auxiliary_hooks import SaliencyMapHookDet
 
 
 class SAMDetectorMixin(BaseDetector):
@@ -13,3 +18,23 @@ class SAMDetectorMixin(BaseDetector):
         # Rest of SAM logics are implented in SAMOptimizerHook
         self.current_batch = data
         return super().train_step(data, optimizer, **kwargs)
+
+    def simple_test(self, img, img_metas, rescale=False, postprocess=True):
+        x = self.extract_feat(img)
+        outs = self.bbox_head(x)
+        with no_nncf_trace():
+            bbox_results = \
+                self.bbox_head.get_bboxes(*outs, img_metas, self.test_cfg, False)
+            if torch.onnx.is_in_onnx_export():
+                feature_vector = get_feature_vector(x)
+                cls_scores = outs[0]
+                saliency_map = SaliencyMapHookDet(self).func(cls_scores, cls_scores_provided=True)
+                feature = feature_vector, saliency_map
+                return bbox_results[0], feature
+
+        if postprocess:
+            bbox_results = [
+                self.postprocess(det_bboxes, det_labels, None, img_metas, rescale=rescale)
+                for det_bboxes, det_labels in bbox_results
+            ]
+        return bbox_results

--- a/mpa/modules/models/detectors/sam_detector_mixin.py
+++ b/mpa/modules/models/detectors/sam_detector_mixin.py
@@ -7,7 +7,7 @@ import torch
 from mmdet.models.detectors import BaseDetector
 from mmdet.utils.deployment.export_helpers import get_feature_vector
 from mmdet.integration.nncf.utils import no_nncf_trace
-from mpa.modules.hooks.auxiliary_hooks import SaliencyMapHookDet
+from mpa.modules.hooks.auxiliary_hooks import DetSaliencyMapHook
 
 
 class SAMDetectorMixin(BaseDetector):
@@ -28,7 +28,7 @@ class SAMDetectorMixin(BaseDetector):
             if torch.onnx.is_in_onnx_export():
                 feature_vector = get_feature_vector(x)
                 cls_scores = outs[0]
-                saliency_map = SaliencyMapHookDet(self).func(cls_scores, cls_scores_provided=True)
+                saliency_map = DetSaliencyMapHook(self).func(cls_scores, cls_scores_provided=True)
                 feature = feature_vector, saliency_map
                 return bbox_results[0], feature
 


### PR DESCRIPTION
Enable class-wise saliency map generation for the detection case.

Tested with all detection models from `external\model-preparation-algorithm\configs\detection\` on PASCAL VOC dataset

related PR:
https://github.com/openvinotoolkit/training_extensions/pull/1402

Some examples (mobilenetv2_ssd):
![image](https://user-images.githubusercontent.com/17028475/204863408-c57878b3-0fce-43fc-8ff4-3f37873dbf43.png)