### PR TITLE
[OTX] Add SupCon recipes for classification task

### DIFF
--- a/mpa/cls/__init__.py
+++ b/mpa/cls/__init__.py
@@ -14,6 +14,7 @@ import mpa.modules.datasets.pipelines.transforms.augmix
 import mpa.modules.datasets.pipelines.transforms.ote_transforms
 import mpa.modules.datasets.pipelines.transforms.random_augment
 import mpa.modules.datasets.pipelines.transforms.random_ratio_crop
+import mpa.modules.datasets.pipelines.transforms.twocrop_transform
 
 import mpa.modules.datasets.cls_csv_dataset
 import mpa.modules.datasets.cls_csv_incr_dataset
@@ -30,6 +31,7 @@ import mpa.modules.models.classifiers
 import mpa.modules.models.heads.cls_incremental_head
 import mpa.modules.models.heads.multi_classifier_head
 import mpa.modules.models.heads.non_linear_cls_head
+import mpa.modules.models.heads.supcon_cls_head
 
 import mpa.modules.models.heads.custom_cls_head
 import mpa.modules.models.heads.custom_multi_label_linear_cls_head
@@ -45,3 +47,4 @@ import mpa.modules.models.losses.ib_loss
 import mpa.modules.models.losses.asymmetric_loss_with_ignore
 import mpa.modules.models.losses.asymmetric_angular_loss_with_ignore
 import mpa.modules.models.losses.triplet_loss
+import mpa.modules.models.losses.barlowtwins_loss

--- a/mpa/modules/datasets/pipelines/transforms/twocrop_transform.py
+++ b/mpa/modules/datasets/pipelines/transforms/twocrop_transform.py
@@ -1,0 +1,29 @@
+# Copyright (C) 2022 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+from copy import deepcopy
+
+import numpy as np
+from mmcls.datasets.builder import PIPELINES
+from mmcls.datasets.pipelines import Compose, to_tensor
+
+from mmcv.utils import build_from_cfg
+
+
+@PIPELINES.register_module()
+class TwoCropTransform():
+    """Generate two different cropped views of an image"""
+
+    def __init__(self, pipeline):
+        self.pipeline1 = Compose([build_from_cfg(p, PIPELINES) for p in pipeline])
+        self.pipeline2 = Compose([build_from_cfg(p, PIPELINES) for p in pipeline])
+
+    def __call__(self, data):
+        data1 = self.pipeline1(deepcopy(data))
+        data2 = self.pipeline2(deepcopy(data))
+
+        data = deepcopy(data1)
+        data["img"] = to_tensor(
+            np.ascontiguousarray(np.stack((data1["img"], data2["img"]), axis=0))
+        )
+        return data

--- a/mpa/modules/models/classifiers/__init__.py
+++ b/mpa/modules/models/classifiers/__init__.py
@@ -7,3 +7,4 @@ from . import semisl_classifier
 from . import task_incremental_classifier
 from . import cls_incremental_classifier
 from . import sam_classifier
+from . import supcon_classifier

--- a/mpa/modules/models/classifiers/supcon_classifier.py
+++ b/mpa/modules/models/classifiers/supcon_classifier.py
@@ -1,0 +1,36 @@
+# Copyright (C) 2022 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+#
+
+import torch
+from torch.nn.functional import softmax
+from mmcls.models.builder import CLASSIFIERS
+from mmcls.models.classifiers.image import ImageClassifier
+
+
+@CLASSIFIERS.register_module()
+class SupConClassifier(ImageClassifier):
+    def __init__(self, backbone=None, neck=None, head=None, pretrained=None, **kwargs):
+        super(SupConClassifier, self).__init__(
+            backbone=backbone,
+            neck=neck,
+            head=head,
+            pretrained=pretrained,
+        )
+        self.hierarchical = False
+        self.multilabel = False
+
+    def forward_train(self, img, gt_label, **kwargs):
+        # concatenate the different image views along the batch size
+        if len(img.shape) == 5:
+            img = torch.cat([img[:, d, :, :, :] for d in range(img.shape[1])], dim=0)
+        x = self.extract_feat(img)
+        losses = dict()
+        loss = self.head.forward_train(x, gt_label)
+        losses.update(loss)
+        return losses
+
+    def extract_prob(self, img):
+        """Test without augmentation."""
+        x = self.extract_feat(img)
+        return softmax(self.head.fc(x)), x

--- a/mpa/modules/models/classifiers/supcon_classifier.py
+++ b/mpa/modules/models/classifiers/supcon_classifier.py
@@ -34,11 +34,3 @@ class SupConClassifier(ImageClassifier):
             loss = self.head.forward_train(x, gt_label)
         losses.update(loss)
         return losses
-
-    def extract_prob(self, img):
-        """Test without augmentation."""
-        x = self.extract_feat(img)
-        if self.multilabel or self.hierarchical:
-            return sigmoid(self.head.fc(x)), x
-        else:
-            return softmax(self.head.fc(x)), x

--- a/mpa/modules/models/classifiers/supcon_classifier.py
+++ b/mpa/modules/models/classifiers/supcon_classifier.py
@@ -11,14 +11,8 @@ from mmcls.models.classifiers.image import ImageClassifier
 @CLASSIFIERS.register_module()
 class SupConClassifier(ImageClassifier):
     def __init__(self, backbone, neck=None, head=None, pretrained=None, **kwargs):
-        if "multilabel" in kwargs:
-            self.multilabel = kwargs.pop("multilabel")
-        else:
-            self.multilabel = False
-        if "hierarchical" in kwargs:
-            self.hierarchical = kwargs.pop("hierarchical")
-        else:
-            self.hierarchical = False
+        self.multilabel = kwargs.pop("multilabel", False)
+        self.hierarchical = kwargs.pop("hierarchical", False)
         super().__init__(backbone, neck=neck, head=head, pretrained=pretrained, **kwargs)
 
     def forward_train(self, img, gt_label, **kwargs):

--- a/mpa/modules/models/heads/supcon_cls_head.py
+++ b/mpa/modules/models/heads/supcon_cls_head.py
@@ -1,0 +1,101 @@
+# Copyright (C) 2022 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+from torch import nn
+import torch.nn.functional as F
+
+from mmcls.models.builder import HEADS, build_loss
+from mmcls.models.heads.base_head import BaseHead
+
+
+@HEADS.register_module()
+class SupConClsHead(BaseHead):
+    """
+    Supervised Contrastive Learning head for Classification using SelfSL
+    Args:
+        num_classes (int): The number of classes of dataset used for training
+        in_channels (int): The channels of input data from the backbone
+        aux_mlp (dict): A dictionary with the out_channels and optionally the
+                         hid_channels of the auxiliary MLP head.
+        loss (dict): The SelfSL loss: BarlowTwinsLoss (default)
+        topk (set): evaluation topk score, default is (1, )
+    """
+
+    def __init__(
+        self,
+        num_classes: int,
+        in_channels: int,
+        aux_mlp,
+        loss,
+        topk=(1,),
+        init_cfg=None,
+        **kwargs
+    ):
+        if in_channels <= 0:
+            raise ValueError(f"in_channels={in_channels} must be a positive integer")
+        if num_classes <= 0:
+            raise ValueError("at least one class must be exist num_classes.")
+
+        if isinstance(topk, int):
+            topk = (topk,)
+        for _topk in topk:
+            assert _topk > 0, "Top-k should be larger than 0"
+        super().__init__(init_cfg=init_cfg)
+
+        self.topk = topk
+        self.compute_loss = build_loss(loss)
+
+        # Set up the standard classification head
+        self.num_classes = num_classes
+        self.linear = nn.Linear(in_features=in_channels, out_features=self.num_classes)
+
+        # Set up the auxiliar head
+        out_channels = aux_mlp["out_channels"]
+        if out_channels <= 0:
+            raise ValueError(f"out_channels={out_channels} must be a positive integer")
+        if "hid_channels" in aux_mlp and aux_mlp["hid_channels"] > 0:
+            hid_channels = aux_mlp["hid_channels"]
+            self.aux_mlp = nn.Sequential(
+                nn.Linear(in_features=in_channels, out_features=hid_channels),
+                nn.ReLU(inplace=True),
+                nn.Linear(in_features=hid_channels, out_features=out_channels),
+            )
+        else:
+            self.aux_mlp = nn.Linear(in_features=in_channels, out_features=out_channels)
+
+    def forward_train(self, x, gt_label):
+        """
+        Forward train head using the Supervised Contrastive Loss
+        Args:
+            x (Tensor): features from the backbone.
+        Returns:
+            dict[str, Tensor]: A dictionary of loss components.
+        """
+
+        losses = {}
+        fc_feats = self.linear(x)
+
+        bsz = gt_label.shape[0]
+        aux_feats = None
+        if x.shape[0] == 2 * bsz:
+            # reshape aux_feats from [2 * bsz, dims] to [bs, 2, dims]
+            feats1, feats2 = torch.split(self.aux_mlp(x), [bsz, bsz], dim=0)
+            aux_feats = torch.cat([feats1.unsqueeze(1), feats2.unsqueeze(1)], dim=1)
+        loss = self.compute_loss(fc_feats, gt_label, aux_feats=aux_feats)
+        losses.update(loss)
+        return losses
+
+    def simple_test(self, img):
+        """
+        Test without data augmentation.
+        """
+        cls_score = self.linear(img)
+
+        if isinstance(cls_score, list):
+            cls_score = sum(cls_score) / float(len(cls_score))
+        pred = F.softmax(cls_score, dim=1) if cls_score is not None else None
+        if torch.onnx.is_in_onnx_export():
+            return pred
+        pred = list(pred.detach().cpu().numpy())
+        return pred

--- a/mpa/modules/models/losses/barlowtwins_loss.py
+++ b/mpa/modules/models/losses/barlowtwins_loss.py
@@ -4,8 +4,7 @@
 import torch
 import torch.nn as nn
 from torch import Tensor
-from mmcls.models.builder import LOSSES, build_loss
-from mmcls.models.losses import CrossEntropyLoss
+from mmcls.models.builder import LOSSES
 
 
 def off_diagonal(x: Tensor):
@@ -24,63 +23,35 @@ class BarlowTwinsLoss(nn.Module):
     Code adapted from https://github.com/facebookresearch/barlowtwins.
     """
 
-    def __init__(self, off_diag_penality, loss_weight=1.0, cls_loss=None):
+    def __init__(self, off_diag_penality, loss_weight=1.0):
         super().__init__()
         self.penalty = off_diag_penality
         self.loss_weight = loss_weight
-        if cls_loss is not None:
-            self.criterion = build_loss(cls_loss)
-        else:
-            self.criterion = None
 
-    def forward(self, fc_feats, gt_labels=None, aux_feats=None):
+    def forward(self, feats1: Tensor, feats2: Tensor, **kwargs):
         """
         Compute Barlow Twins Loss and, if labels are not none,
         also the Cross-Entropy loss.
         Args:
-            fc_feats: tensor to train the linear classifier on
-            labels: ground truth of shape [bsz].
-            aux_feats: hidden vector of shape [bsz, n_views, ...].
+            feats1, feats2: vectors of shape [bsz, ...]. Corresponding to
+                            two views of the same samples
         Returns:
-            A dictionary containing the loss in the 'loss' key.
+            A floating point number describing the Barlow Twins loss
         """
-        losses = {}
-        losses["loss"] = 0
 
-        # Cross-Entropy loss: classification loss
-        if isinstance(self.criterion, CrossEntropyLoss):
-            if fc_feats is not None and gt_labels is not None:
-                gt_labels = gt_labels.squeeze(dim=1)
-                if fc_feats.shape[0] == gt_labels.shape[0] * 2:
-                    losses["loss"] = self.criterion(fc_feats, torch.cat([gt_labels, gt_labels], dim=0))
-                else:
-                    losses["loss"] = self.criterion(fc_feats, gt_labels)
-        else:
-            raise NotImplementedError("Losses other than CrossEntropyLoss are not yet supported")
-
-        losses["loss"] *= self.criterion.loss_weight
-
-        if aux_feats is None:
-            return losses
-
-        if len(aux_feats.shape) < 3:
-            raise ValueError("`aux_feats` needs to be [bsz, n_views, ...]," "at least 3 dimensions are required")
-        if len(aux_feats.shape) > 3:
-            aux_feats = aux_feats.view(aux_feats.shape[0], aux_feats.shape[1], -1)
-
-        batch_size = aux_feats.shape[0]
-        dimensionality = aux_feats.shape[2]
+        batch_size = feats1.shape[0]
+        assert batch_size == feats2.shape[0]
+        dimensionality = feats1.shape[1]
+        assert dimensionality == feats2.shape[1]
 
         # Barlow Twins loss: redundancy reduction
         batch_norm = nn.BatchNorm1d(dimensionality, affine=False, track_running_stats=False)
         # empirical cross-correlation matrix
-        eccm = batch_norm(aux_feats[:, 0, :]).T @ batch_norm(aux_feats[:, 1, :])
+        eccm = batch_norm(feats1).T @ batch_norm(feats2)
         eccm.div_(batch_size)
 
         # Compute the invariance term (diagonal) and redundacy term (off-diagonal)
         on_diag = torch.diagonal(eccm).add(-1).pow_(2).sum()
         off_diag = off_diagonal(eccm).pow_(2).sum()
         # Normalize the loss by the dimensionality of the projector
-        losses["loss"] += self.loss_weight * (on_diag + self.penalty * off_diag) / dimensionality
-
-        return losses
+        return self.loss_weight * (on_diag + self.penalty * off_diag) / dimensionality

--- a/mpa/modules/models/losses/barlowtwins_loss.py
+++ b/mpa/modules/models/losses/barlowtwins_loss.py
@@ -1,0 +1,86 @@
+# Copyright (C) 2022 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+import torch.nn as nn
+from torch import Tensor
+from mmcls.models.builder import LOSSES, build_loss
+from mmcls.models.losses import CrossEntropyLoss
+
+
+def off_diagonal(x: Tensor):
+    """
+    return a tensor containing all the elements outside the diagonal of x
+    """
+    assert x.shape[0] == x.shape[1]
+    return x.flatten()[:-1].view(x.shape[0] - 1, x.shape[0] + 1)[:, 1:].flatten()
+
+
+@LOSSES.register_module()
+class BarlowTwinsLoss(nn.Module):
+    """
+    Barlow Twins Loss: https://arxiv.org/abs/2103.03230.
+    Self-Supervised Learning via Redundancy Reduction
+    Code adapted from https://github.com/facebookresearch/barlowtwins.
+    """
+
+    def __init__(self, off_diag_penality, loss_weight=1.0, cls_loss=None):
+        super().__init__()
+        self.penalty = off_diag_penality
+        self.loss_weight = loss_weight
+        if cls_loss is not None:
+            self.criterion = build_loss(cls_loss)
+        else:
+            self.criterion = None
+
+    def forward(self, fc_feats, gt_labels=None, aux_feats=None):
+        """
+        Compute Barlow Twins Loss and, if labels are not none,
+        also the Cross-Entropy loss.
+        Args:
+            fc_feats: tensor to train the linear classifier on
+            labels: ground truth of shape [bsz].
+            aux_feats: hidden vector of shape [bsz, n_views, ...].
+        Returns:
+            A dictionary containing the loss in the 'loss' key.
+        """
+        losses = {}
+        losses["loss"] = 0
+
+        # Cross-Entropy loss: classification loss
+        if isinstance(self.criterion, CrossEntropyLoss):
+            if fc_feats is not None and gt_labels is not None:
+                gt_labels = gt_labels.squeeze(dim=1)
+                if fc_feats.shape[0] == gt_labels.shape[0] * 2:
+                    losses["loss"] = self.criterion(fc_feats, torch.cat([gt_labels, gt_labels], dim=0))
+                else:
+                    losses["loss"] = self.criterion(fc_feats, gt_labels)
+        else:
+            raise NotImplementedError("Losses other than CrossEntropyLoss are not yet supported")
+
+        losses["loss"] *= self.criterion.loss_weight
+
+        if aux_feats is None:
+            return losses
+
+        if len(aux_feats.shape) < 3:
+            raise ValueError("`aux_feats` needs to be [bsz, n_views, ...]," "at least 3 dimensions are required")
+        if len(aux_feats.shape) > 3:
+            aux_feats = aux_feats.view(aux_feats.shape[0], aux_feats.shape[1], -1)
+
+        batch_size = aux_feats.shape[0]
+        dimensionality = aux_feats.shape[2]
+
+        # Barlow Twins loss: redundancy reduction
+        batch_norm = nn.BatchNorm1d(dimensionality, affine=False, track_running_stats=False)
+        # empirical cross-correlation matrix
+        eccm = batch_norm(aux_feats[:, 0, :]).T @ batch_norm(aux_feats[:, 1, :])
+        eccm.div_(batch_size)
+
+        # Compute the invariance term (diagonal) and redundacy term (off-diagonal)
+        on_diag = torch.diagonal(eccm).add(-1).pow_(2).sum()
+        off_diag = off_diagonal(eccm).pow_(2).sum()
+        # Normalize the loss by the dimensionality of the projector
+        losses["loss"] += self.loss_weight * (on_diag + self.penalty * off_diag) / dimensionality
+
+        return losses

--- a/recipes/stages/_base_/data/pipelines/twocrop_pipeline.py
+++ b/recipes/stages/_base_/data/pipelines/twocrop_pipeline.py
@@ -1,0 +1,29 @@
+img_norm_cfg = dict(
+    mean=[123.675, 116.28, 103.53], std=[58.395, 57.12, 57.375], to_rgb=True
+)
+__resize_target_size = 224
+
+
+train_pipeline = [
+    dict(
+        type="TwoCropTransform",
+        pipeline=[
+            dict(type="Resize", size=__resize_target_size),
+            dict(type="RandomFlip", flip_prob=0.5, direction="horizontal"),
+            dict(type="AugMixAugment", config_str="augmix-m5-w3"),
+            dict(type="RandomRotate", p=0.35, angle=(-10, 10)),
+            dict(type="ToNumpy"),
+            dict(type="Normalize", **img_norm_cfg),
+            dict(type="ImageToTensor", keys=["img"]),
+            dict(type="ToTensor", keys=["gt_label"]),
+            dict(type="Collect", keys=["img", "gt_label"]),
+        ],
+    )
+]
+
+test_pipeline = [
+    dict(type="Resize", size=__resize_target_size),
+    dict(type="Normalize", **img_norm_cfg),
+    dict(type="ImageToTensor", keys=["img"]),
+    dict(type="Collect", keys=["img"]),
+]

--- a/recipes/stages/_base_/data/twocrop_data.py
+++ b/recipes/stages/_base_/data/twocrop_data.py
@@ -1,0 +1,26 @@
+_base_ = [
+    './pipelines/twocrop_pipeline.py'
+]
+
+__dataset_type = 'ClsDirDataset'
+
+__train_pipeline = {{_base_.train_pipeline}}
+__test_pipeline = {{_base_.test_pipeline}}
+
+__samples_per_gpu = 32
+
+data = dict(
+    samples_per_gpu=__samples_per_gpu,
+    workers_per_gpu=2,
+    train=dict(
+        type=__dataset_type,
+        pipeline=__train_pipeline),
+    val=dict(
+        type=__dataset_type,
+        test_mode=True,
+        pipeline=__test_pipeline),
+    test=dict(
+        type=__dataset_type,
+        test_mode=True,
+        pipeline=__test_pipeline)
+)

--- a/recipes/stages/_base_/data/twocrop_data.py
+++ b/recipes/stages/_base_/data/twocrop_data.py
@@ -7,7 +7,7 @@ __dataset_type = 'ClsDirDataset'
 __train_pipeline = {{_base_.train_pipeline}}
 __test_pipeline = {{_base_.test_pipeline}}
 
-__samples_per_gpu = 32
+__samples_per_gpu = 16
 
 data = dict(
     samples_per_gpu=__samples_per_gpu,

--- a/recipes/stages/_base_/models/cls_supcon.py
+++ b/recipes/stages/_base_/models/cls_supcon.py
@@ -1,0 +1,25 @@
+_base_ = './model.py'
+
+model = dict(
+    type="SupConClassifier",
+    task="classification",
+    pretrained=None,
+    backbone=dict(),
+    neck=dict(type="GlobalAveragePooling"),
+    head=dict(
+        type="SupConClsHead",
+        num_classes=10,
+        in_channels=-1,
+        aux_mlp=dict(hid_channels=0, out_channels=1024),
+        loss=dict(
+            type="BarlowTwinsLoss",
+            off_diag_penality=1.0 / 128.0,
+            loss_weight=1.0,
+            cls_loss=dict(type="CrossEntropyLoss", loss_weight=1.0),
+        ),
+    ),
+)
+
+checkpoint_config = dict(
+    type="CheckpointHookWithValResults"
+)

--- a/recipes/stages/_base_/models/cls_supcon.py
+++ b/recipes/stages/_base_/models/cls_supcon.py
@@ -11,11 +11,11 @@ model = dict(
         num_classes=10,
         in_channels=-1,
         aux_mlp=dict(hid_channels=0, out_channels=1024),
-        loss=dict(
+        loss=dict(type="CrossEntropyLoss", loss_weight=1.0),
+        aux_loss=dict(
             type="BarlowTwinsLoss",
             off_diag_penality=1.0 / 128.0,
             loss_weight=1.0,
-            cls_loss=dict(type="CrossEntropyLoss", loss_weight=1.0),
         ),
     ),
 )

--- a/recipes/stages/classification/supcon.yaml
+++ b/recipes/stages/classification/supcon.yaml
@@ -19,3 +19,6 @@ optimizer:
 evaluation:
     metric: ['accuracy', 'class_accuracy']
 
+task_adapt:
+    type: 'mpa'
+    op: 'REPLACE'

--- a/recipes/stages/classification/supcon.yaml
+++ b/recipes/stages/classification/supcon.yaml
@@ -1,0 +1,21 @@
+_base_: [
+    './train.yaml',
+    '../_base_/data/twocrop_data.py',
+    '../_base_/models/cls_supcon.py',
+]
+
+runner:
+    max_epochs: 20
+
+optimizer_config:
+    type: SAMOptimizerHook
+
+optimizer:
+    type: SGD
+    lr: 0.005
+    momentum: 0.9
+    weight_decay: 0.0005
+
+evaluation:
+    metric: ['accuracy', 'class_accuracy']
+


### PR DESCRIPTION
This PR contains recipes for training models using a [SupCon](https://arxiv.org/abs/2004.11362)-like style.

These recipes aim to increase the current classification baseline when the data is scarce.

Procedure:
- Train a model with two heads:
  - classification head with standard cross-entropy loss.
  - SupCon head with custom SelfSL loss (currently it uses the [Barlow Twins](https://arxiv.org/abs/2103.03230) loss).
- At inference, the SupCon head is discarded, hence incurring no overhead at runtime.

The recipes include:
- a data pipeline using TwoCrop transform (to generate two views of an image for the SelfSL head)
- a SupConClassifier (in charge of handling the two views of images)
- a SupConClsHead (the one that uses the dual-head approach)
- a SelfSL loss (the Barlow Twins loss)

So far, this method will be used in OTX when specifying the `TrainType` as `SUPERVISEDCONTRASTIVE`.