### PR TITLE
[OTX] Fix Classification Stage & Classifier for supporting public backbone

### DIFF
--- a/mpa/cls/stage.py
+++ b/mpa/cls/stage.py
@@ -121,7 +121,7 @@ class ClsStage(Stage):
             return
 
         # update model layer's in/out configuration
-        from mmcls.models.builder import BACKBONES as backbone_reg
+        from mmcv.cnn import MODELS as backbone_reg
         layer = build_from_cfg(cfg.model.backbone, backbone_reg)
         layer.eval()
         input_shape = [3, 224, 224]

--- a/mpa/modules/models/classifiers/sam_classifier.py
+++ b/mpa/modules/models/classifiers/sam_classifier.py
@@ -257,16 +257,18 @@ class SAMImageClassifier(ImageClassifier):
            Overriding for OpenVINO export with features
         """
         x = self.backbone(img)
-        # For Global Backbones (det/seg/etc..),
-        # In case of tuple, only the feat of the last layer is used.
-        if isinstance(x, tuple):
-            x = x[-1]
 
         if torch.onnx.is_in_onnx_export():
             self.featuremap = x
 
         if self.with_neck:
             x = self.neck(x)
+
+        # For Global Backbones (det/seg/etc..),
+        # In case of tuple, only the feat of the last layer is used.
+        if isinstance(x, tuple):
+            x = x[-1]
+
         return x
 
     def simple_test(self, img, img_metas):

--- a/mpa/modules/models/classifiers/sam_classifier.py
+++ b/mpa/modules/models/classifiers/sam_classifier.py
@@ -257,6 +257,11 @@ class SAMImageClassifier(ImageClassifier):
            Overriding for OpenVINO export with features
         """
         x = self.backbone(img)
+        # For Global Backbones (det/seg/etc..),
+        # In case of tuple, only the feat of the last layer is used.
+        if isinstance(x, tuple):
+            x = x[-1]
+
         if torch.onnx.is_in_onnx_export():
             self.featuremap = x
 

--- a/mpa/modules/models/classifiers/sam_classifier.py
+++ b/mpa/modules/models/classifiers/sam_classifier.py
@@ -257,17 +257,16 @@ class SAMImageClassifier(ImageClassifier):
            Overriding for OpenVINO export with features
         """
         x = self.backbone(img)
+        # For Global Backbones (det/seg/etc..),
+        # In case of tuple or list, only the feat of the last layer is used.
+        if isinstance(x, (tuple, list)):
+            x = x[-1]
 
         if torch.onnx.is_in_onnx_export():
             self.featuremap = x
 
         if self.with_neck:
             x = self.neck(x)
-
-        # For Global Backbones (det/seg/etc..),
-        # In case of tuple, only the feat of the last layer is used.
-        if isinstance(x, tuple):
-            x = x[-1]
 
         return x
 


### PR DESCRIPTION
## Summary
BACKBONE Registy change mmcls to mmcv used in Classification Stage
If the output of the backbone is a tuple (other tasks backbone), 
adjust the classification head to receive the output of the last layer

Through this work, i confirmed the backbone replacement, build, and training of mmdet, mmseg, torchvision, and omz based on SAMImageClassifier

![image](https://user-images.githubusercontent.com/38045080/208012102-ba7b2aa1-24b0-4688-a26d-ca23eee07bbe.png)
