### PR TITLE
[Hot-fix] Fix zero-division error in one cycle lr scheduler in multilabel classification

### DIFF
--- a/recipes/stages/_base_/schedules/1cycle.py
+++ b/recipes/stages/_base_/schedules/1cycle.py
@@ -2,7 +2,7 @@ _base_ = './schedule.py'
 
 lr_config = dict(
     policy='OneCycle',
-    pct_start=0.2,
+    pct_start=0.200001,
     div_factor=100,
     final_div_factor=1000
 )


### PR DESCRIPTION
This is for fixing the bug ticket -> https://jira.devtools.intel.com/browse/CVS-99293

This issue was caused because end_iters in onecyclelr scheduler is updated as 1(this value, 1 makes zerodivision error should be avoided) when epoch is set to 5. (end_iters = pct_value * num_epoch) -> https://github.com/open-mmlab/mmcv/blob/46eb9ec5d07ea344ed43056d007a7eb71dc3ee98/mmcv/runner/hooks/lr_updater.py#L648. I fixed it by adding more decimal in pct_value.