### PR TITLE
[OTX] bugfix: single gpu classification training error

### DIFF
--- a/mpa/cls/stage.py
+++ b/mpa/cls/stage.py
@@ -317,7 +317,7 @@ class ClsStage(Stage):
                     find_unused_parameters=find_unused_parameters)
             else:
                 model = MMDataParallel(
-                    model.cuda(cfg.gpu_ids[0]), device_ids=cfg.gpu_ids)
+                    model.cuda(), device_ids=[0])
         else:
             model = MMDataCPU(model)
 

--- a/mpa/seg/inferrer.py
+++ b/mpa/seg/inferrer.py
@@ -121,8 +121,7 @@ class SegInferrer(SegStage):
                     broadcast_buffers=False,
                     find_unused_parameters=find_unused_parameters)
             else:
-                model = MMDataParallel(model.cuda(cfg.gpu_ids[0]),
-                                            device_ids=cfg.gpu_ids)
+                model = MMDataParallel(model.cuda(), device_ids=[0])
         else:
             model = MMDataCPU(model)
 

--- a/mpa/seg/train.py
+++ b/mpa/seg/train.py
@@ -74,8 +74,7 @@ def train_segmentor(model,
                 broadcast_buffers=False,
                 find_unused_parameters=find_unused_parameters)
         else:
-            model = MMDataParallel(
-                model.cuda(cfg.gpu_ids[0]), device_ids=cfg.gpu_ids)
+            model = MMDataParallel(model.cuda(), device_ids=[0])
     else:
         model = MMDataCPU(model)
 

--- a/mpa/stage.py
+++ b/mpa/stage.py
@@ -158,7 +158,7 @@ class Stage(object):
             gpu_ids = os.environ.get('CUDA_VISIBLE_DEVICES')
             logger.info(f'CUDA_VISIBLE_DEVICES = {gpu_ids}')
             if gpu_ids is not None:
-                self.cfg.gpu_ids = [int(gpu_ids.split(',')[0])]
+                self.cfg.gpu_ids = range(len(gpu_ids.split(',')))
             else:
                 self.cfg.gpu_ids = range(1)
 


### PR DESCRIPTION
When classification task runs with single GPU, error occurs.
The reason why error occurs is using GPU index as 1 not 0 when `CUDA_VISIBLE_DEVICES` is set as 1 even if number of visible GPU is 1.
I implemented to make classification task use only first GPU when single GPU training as detection task does.