### PR TITLE
Add pyx files to source distribution

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 recursive-include recipes *
+include mpa/modules/datasets/pipelines/transforms/cython_augments/*.pyx
 exclude mpa/modules/datasets/pipelines/transforms/cython_augments/*.c
 exclude mpa/modules/datasets/pipelines/transforms/cython_augments/*.html


### PR DESCRIPTION
While working on https://github.com/openvinotoolkit/training_extensions/pull/1505, I found that I missed including `*.pyx` files in our project source distribution. If they are missed, installing package from the source distribution will not be working, e.g., `tox`.

Signed-off-by: Kim, Vinnam <vinnam.kim@intel.com>