### PR TITLE
Fix ignore filtering in hierarchical heads

### DIFF
--- a/mpa/modules/models/heads/custom_hierarchical_linear_cls_head.py
+++ b/mpa/modules/models/heads/custom_hierarchical_linear_cls_head.py
@@ -95,12 +95,13 @@ class CustomHierarchicalLinearClsHead(MultiLabelClsHead):
         if self.compute_multilabel_loss:
             head_gt = gt_label[:, self.hierarchical_info['num_multiclass_heads']:]
             head_logits = cls_score[:, self.hierarchical_info['num_single_label_classes']:]
-            valid_mask = head_gt >= 0
-            head_gt = head_gt[valid_mask].view(*valid_mask.shape)
-            head_logits = head_logits[valid_mask].view(*valid_mask.shape)
+            valid_batch_mask = head_gt >= 0
+            head_gt = head_gt[valid_batch_mask, ]
+            head_logits = head_logits[valid_batch_mask, ]
 
             # multilabel_loss is assumed to perform no batch averaging
             valid_label_mask = self.get_valid_label_mask(img_metas=img_metas)[:, self.hierarchical_info['num_single_label_classes']:]
+            valid_label_mask = valid_label_mask[valid_batch_mask, ]
             multilabel_loss = self.loss(head_logits, head_gt, multilabel=True, valid_label_mask=valid_label_mask)
             losses['loss'] += multilabel_loss.mean()
         return losses

--- a/mpa/modules/models/heads/custom_hierarchical_non_linear_cls_head.py
+++ b/mpa/modules/models/heads/custom_hierarchical_non_linear_cls_head.py
@@ -122,12 +122,13 @@ class CustomHierarchicalNonLinearClsHead(MultiLabelClsHead):
         if self.compute_multilabel_loss:
             head_gt = gt_label[:, self.hierarchical_info['num_multiclass_heads']:]
             head_logits = cls_score[:, self.hierarchical_info['num_single_label_classes']:]
-            valid_mask = head_gt >= 0
-            head_gt = head_gt[valid_mask].view(*valid_mask.shape)
-            head_logits = head_logits[valid_mask].view(*valid_mask.shape)
+            valid_batch_mask = head_gt >= 0
+            head_gt = head_gt[valid_batch_mask, ]
+            head_logits = head_logits[valid_batch_mask, ]
 
             # multilabel_loss is assumed to perform no batch averaging
             valid_label_mask = self.get_valid_label_mask(img_metas=img_metas)[:, self.hierarchical_info['num_single_label_classes']:]
+            valid_label_mask = valid_label_mask[valid_batch_mask, ]
             multilabel_loss = self.loss(head_logits, head_gt, multilabel=True, valid_label_mask=valid_label_mask)
             losses['loss'] += multilabel_loss.mean()
         return losses


### PR DESCRIPTION
Batch size after filtering should be different then the initial size if there are filtered elements